### PR TITLE
Adjust Year 8 semester pair period totals

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -791,8 +791,21 @@
                 }
 
                 const subjectList = Array.isArray(value) ? value : [value];
-                subjectList.forEach(subject => {
-                    totals[teacherIndex] += getSubjectPeriodValue(subject);
+                const validSubjects = subjectList.filter(subject => typeof subject === 'string' && subject.trim() !== '');
+
+                if (validSubjects.length === 0) {
+                    return;
+                }
+
+                const periodValues = validSubjects.map(subject => getSubjectPeriodValue(subject));
+
+                if (isYear8SemesterPair(validSubjects) && periodValues.every(value => value === YEAR8_ELECTIVE_PERIODS)) {
+                    totals[teacherIndex] += YEAR8_ELECTIVE_PERIODS;
+                    return;
+                }
+
+                periodValues.forEach(periodValue => {
+                    totals[teacherIndex] += periodValue;
                 });
             });
 


### PR DESCRIPTION
## Summary
- prevent Year 8 semester 1/semester 2 elective pairs from being double-counted in teacher period totals
- ignore empty subject entries when computing allocation totals to avoid spurious period counts

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ce90217bcc832693b1b2df7a84f782