### PR TITLE
Adjust clash slot colors to contrast with allocations

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -176,8 +176,8 @@
         }
 
         .drop-zone.clash-cell {
-            background: #fdecea;
-            border-color: #e74c3c;
+            background: #fff7e6;
+            border-color: #f39c12;
         }
 
         .drop-zone.semester-pair-cell {
@@ -186,9 +186,9 @@
         }
 
         .subject-slot.clash {
-            background: #fdecea;
-            border: 2px solid #e74c3c;
-            color: #c0392b;
+            background: #fff4e6;
+            border: 2px solid #f39c12;
+            color: #b9770e;
         }
 
         .subject-slot.semester-pair {
@@ -420,8 +420,8 @@
         }
 
         .legend-color.clash {
-            background: #fdecea;
-            border: 2px solid #e74c3c;
+            background: #fff4e6;
+            border: 2px solid #f39c12;
         }
 
         /* Autocomplete styles */


### PR DESCRIPTION
## Summary
- update clash cell, subject, and legend colors so clashes are visually distinct from standard allocations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce914ab86483269020b2ee459de197