### PR TITLE
Brighten Year 8 pair legend color

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -181,7 +181,7 @@
         }
 
         .drop-zone.semester-pair-cell {
-            background: #f5f9eb;
+            background: #d4edda;
             border-color: #27ae60;
         }
 
@@ -192,7 +192,7 @@
         }
 
         .subject-slot.semester-pair {
-            background: #f5f9eb;
+            background: #d4edda;
             border: 2px solid #27ae60;
             color: #1e8449;
             display: flex;
@@ -415,7 +415,7 @@
         }
 
         .legend-color.semester-pair {
-            background: #f5f9eb;
+            background: #d4edda;
             border: 2px solid #27ae60;
         }
 


### PR DESCRIPTION
## Summary
- update the Year 8 S1/S2 pair styling to use a deeper green tone
- ensure the legend chip matches the semester pair cell appearance

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ce9246741c8326a9fa3be509fd5341