### PR TITLE
Enable dragging allocations between teachers

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -279,6 +279,7 @@
             border-radius: 4px;
             padding: 2px 4px;
             font-size: 11px;
+            cursor: move;
         }
 
         .subject-slot.semester-pair .semester-pair-label {
@@ -2105,6 +2106,31 @@
             }
         }
 
+        function enhanceAllocatedSubjectElement(element, subjectCode, lineIndex, teacherIndex) {
+            if (!element) {
+                return;
+            }
+
+            element.dataset.subject = subjectCode;
+            element.dataset.teacher = teacherIndex;
+            element.dataset.line = lineIndex;
+            element.dataset.allocationState = 'allocated';
+            element.draggable = true;
+
+            element.addEventListener('dragstart', handleDragStart);
+            element.addEventListener('dragend', handleDragEnd);
+            element.addEventListener('click', function(e) {
+                e.preventDefault();
+                e.stopPropagation();
+
+                if (draggedElement || element.classList.contains('dragging')) {
+                    return;
+                }
+
+                handleSubjectRemoval(lineIndex, teacherIndex, subjectCode);
+            });
+        }
+
         function renderCell(lineIndex, teacherIndex) {
             const cell = document.querySelector(`[data-period="${lineIndex}"][data-teacher="${teacherIndex}"]`);
             if (!cell) {
@@ -2133,11 +2159,7 @@
                     const subjectRow = document.createElement('div');
                     subjectRow.className = 'semester-pair-item';
                     subjectRow.textContent = subject;
-                    subjectRow.dataset.subject = subject;
-                    subjectRow.addEventListener('click', function(e) {
-                        e.stopPropagation();
-                        handleSubjectRemoval(lineIndex, teacherIndex, subject);
-                    });
+                    enhanceAllocatedSubjectElement(subjectRow, subject, lineIndex, teacherIndex);
                     wrapper.appendChild(subjectRow);
                 });
 
@@ -2181,13 +2203,7 @@
                     forceSegmentStyle: shouldForceSegment
                 });
 
-                subjectElement.dataset.subject = subject;
-                subjectElement.dataset.teacher = teacherIndex;
-                subjectElement.dataset.line = lineIndex;
-                subjectElement.addEventListener('click', function(e) {
-                    e.stopPropagation();
-                    handleSubjectRemoval(lineIndex, teacherIndex, subject);
-                });
+                enhanceAllocatedSubjectElement(subjectElement, subject, lineIndex, teacherIndex);
                 cell.appendChild(subjectElement);
             });
         }
@@ -2474,11 +2490,17 @@
             }
 
             const subject = draggedElement.dataset.subject;
-            const period = parseInt(cell.dataset.period);
-            const teacher = parseInt(cell.dataset.teacher);
+            if (!subject) {
+                return;
+            }
+
+            const period = parseInt(cell.dataset.period, 10);
+            const teacher = parseInt(cell.dataset.teacher, 10);
+            const isAllocatedElement = draggedElement.classList.contains('allocated')
+                || draggedElement.dataset.allocationState === 'allocated';
 
             if (allocateSubjectToTeacher(subject, teacher, period)) {
-                if (!draggedElement.classList.contains('allocated')) {
+                if (!isAllocatedElement) {
                     draggedElement.remove();
                 }
             }


### PR DESCRIPTION
## Summary
- add a helper to attach drag/move/remove behaviour to allocated timetable entries
- make rendered allocations draggable and reuse the helper for semester pair rows
- update the drop handler and styling so allocations can be dragged between teachers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf113fdb708326a003173c49187b4c