### PR TITLE
Remove deprecated management shortcuts

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -1227,9 +1227,6 @@
                     <div class="control-group-label">Management &amp; Utilities</div>
                     <div class="control-group-buttons">
                         <button class="btn btn-primary" onclick="openManagementHub()" title="Open tools to manage teachers, subjects, lines and supplemental data">Management Hub</button>
-                        <button class="btn btn-danger" onclick="promptRemoveTeacher()" title="Remove a teacher and return any allocated subjects to the pool">Remove Teacher</button>
-                        <button class="btn btn-danger" onclick="promptRemoveSubject()" title="Remove a subject code and clear any allocations">Remove Subject</button>
-                        <button class="btn btn-danger" onclick="promptRemoveLine()" title="Delete a timetable line and return allocated subjects to the pool">Remove Line</button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- remove the dedicated Remove Teacher/Subject/Line buttons from the Management & Utilities control group now that the management hub handles these actions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf417096a08326bfd2cc68aaf141a9