### PR TITLE
Move management hub button into allocation workflow controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -1831,6 +1831,7 @@
                             <button class="btn btn-primary" onclick="allocateNewSubject()" title="Allocate an available subject to a teacher">Allocate New Subject</button>
                             <button class="btn btn-primary" onclick="splitSubject()" title="Divide a subject into multiple allocations">Split Subject</button>
                             <button class="btn btn-primary" onclick="moveExistingAllocation()" title="Reassign a subject that is already allocated">Move Existing Allocation</button>
+                            <button class="btn btn-primary" onclick="openManagementHub()" title="Open tools to manage teachers, subjects, lines and supplemental data">Management Hub</button>
                         </div>
                     </section>
 
@@ -1860,15 +1861,6 @@
                         </div>
                     </section>
 
-                    <section class="control-group control-group--management">
-                        <div class="control-group-header">
-                            <div class="control-group-label">Management &amp; Utilities</div>
-                            <p class="control-group-description">Open advanced tools to manage teachers, subjects, lines and supplemental data.</p>
-                        </div>
-                        <div class="control-group-buttons">
-                            <button class="btn btn-primary" onclick="openManagementHub()" title="Open tools to manage teachers, subjects, lines and supplemental data">Management Hub</button>
-                        </div>
-                    </section>
                 </div>
             </aside>
 


### PR DESCRIPTION
## Summary
- Add the Management Hub action to the Allocation Workflow button group so it appears with other allocation controls
- Remove the redundant Management & Utilities sidebar section to streamline the control hub layout

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0ffd2e7e48326a47e27d3354780c4