### PR TITLE
Tighten timetable spacing for denser layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -673,10 +673,11 @@
         }
 
         .timetable {
-            min-width: 1000px;
+            min-width: 900px;
             width: 100%;
             border-collapse: separate;
             border-spacing: 0;
+            font-size: 0.9rem;
         }
 
         .timetable thead th:first-child {
@@ -690,17 +691,17 @@
         .timetable th {
             background: linear-gradient(135deg, rgba(15, 23, 42, 0.9), rgba(30, 41, 59, 0.9));
             color: #f8fafc;
-            padding: 16px 12px;
+            padding: 12px 10px;
             text-align: center;
             font-weight: 600;
             border: none;
         }
 
         .timetable td {
-            padding: 12px;
+            padding: 8px;
             border: 1px solid rgba(15, 23, 42, 0.08);
             vertical-align: top;
-            min-height: 72px;
+            min-height: 52px;
             background: rgba(248, 250, 255, 0.96);
             position: relative;
         }
@@ -736,11 +737,11 @@
             background: rgba(99, 102, 241, 0.16);
             border: 1.5px dashed rgba(99, 102, 241, 0.45);
             border-radius: 12px;
-            padding: 10px 12px;
-            margin: 4px 0;
+            padding: 6px 8px;
+            margin: 2px 0;
             cursor: move;
             transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, border-color 0.2s ease;
-            min-height: 46px;
+            min-height: 36px;
             display: flex;
             align-items: center;
             justify-content: center;


### PR DESCRIPTION
## Summary
- reduce the timetable's minimum width and base font size so it fits more content on screen
- trim header and cell padding along with minimum heights for a more compact default layout
- tighten subject slot spacing to reduce vertical whitespace inside allocations

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68d1201fc820832691bbf06e067359fa