### PR TITLE
Add lateral margin to subject pool section

### DIFF
--- a/index.html
+++ b/index.html
@@ -931,7 +931,7 @@
         }
 
         .subject-pool-section {
-            margin-top: 32px;
+            margin: 32px clamp(16px, 4vw, 36px) 0;
             display: flex;
             flex-direction: column;
             gap: 16px;
@@ -966,7 +966,7 @@
         }
 
         .teacher-period-summary {
-            margin-top: 28px;
+            margin: 28px clamp(16px, 4vw, 36px) 0;
             padding: 28px;
             background: linear-gradient(135deg, rgba(99, 102, 241, 0.12), rgba(56, 189, 248, 0.1));
             border-radius: 24px;


### PR DESCRIPTION
## Summary
- add responsive horizontal margins around the subject pool so it no longer sits flush against the container edge
- align the teacher period summary card with the same horizontal spacing for visual consistency

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d121b2d2b48326945fc75ea3ee12a6