### PR TITLE
Enable room editing for Year 8 semester pairs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1285,9 +1285,18 @@
         .subject-slot.semester-pair .semester-pair-item {
             background: rgba(5, 150, 105, 0.12);
             border-radius: 6px;
-            padding: 2px 4px;
+            padding: 6px 8px;
             font-size: 11px;
             cursor: move;
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+            align-items: stretch;
+            text-align: left;
+        }
+
+        .subject-slot.semester-pair .semester-pair-item .subject-room-footer {
+            margin-top: 4px;
         }
 
         .subject-slot.semester-pair .semester-pair-label {
@@ -7579,6 +7588,11 @@
                     const subjectRow = document.createElement('div');
                     subjectRow.className = 'semester-pair-item';
                     subjectRow.textContent = subject;
+                    appendSubjectRoomDetails(subjectRow, subject, {
+                        context: 'cell',
+                        lineIndex: lineIndex,
+                        teacherIndex: teacherIndex
+                    });
                     enhanceAllocatedSubjectElement(subjectRow, subject, lineIndex, teacherIndex);
                     wrapper.appendChild(subjectRow);
                 });


### PR DESCRIPTION
## Summary
- attach room controls to each subject within a Year 8 semester pair allocation
- adjust the semester pair item styling so room tags and buttons render cleanly

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d38294ed648326a909e3e8e463ae0f