### PR TITLE
Ensure clashes override Year 8 semester pair styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1310,6 +1310,38 @@
             margin-top: 4px;
         }
 
+        .drop-zone.semester-pair-cell.room-clash-cell,
+        .drop-zone.semester-pair-cell.clash-cell {
+            background: rgba(59, 130, 246, 0.18);
+            border-color: rgba(37, 99, 235, 0.75);
+        }
+
+        .subject-slot.semester-pair.room-clash,
+        .subject-slot.semester-pair.clash {
+            background: rgba(59, 130, 246, 0.18);
+            border: 1.5px solid rgba(37, 99, 235, 0.65);
+            color: #1d4ed8;
+        }
+
+        .subject-slot.semester-pair.room-clash .semester-pair-item,
+        .subject-slot.semester-pair.clash .semester-pair-item {
+            background: rgba(37, 99, 235, 0.08);
+        }
+
+        .subject-slot.semester-pair.room-clash .semester-pair-label,
+        .subject-slot.semester-pair.clash .semester-pair-label {
+            color: #1d4ed8;
+            border-top-color: rgba(37, 99, 235, 0.3);
+        }
+
+        .subject-slot.semester-pair.room-clash .subject-room-tag,
+        .subject-slot.semester-pair.clash .subject-room-tag,
+        .subject-slot.semester-pair.room-clash .subject-room-empty,
+        .subject-slot.semester-pair.clash .subject-room-empty {
+            background: rgba(37, 99, 235, 0.12);
+            color: #1d4ed8;
+        }
+
         .subject-room-footer {
             margin-top: 6px;
             display: flex;


### PR DESCRIPTION
## Summary
- allow room and allocation clash highlighting to override the Year 8 semester pair styling
- update the semester pair subject and cell accents so clash colours remain readable, including room tags

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d384e0a9648326b1ac0e9addb5a84d