### PR TITLE
Delay alert dialog activation until next frame

### DIFF
--- a/index.html
+++ b/index.html
@@ -2850,6 +2850,7 @@
             let activeItem = null;
             let previousActiveElement = null;
             let currentActionButtons = [];
+            let showScheduled = false;
 
             const inferPresentation = text => {
                 const normalized = text.toLowerCase();
@@ -3054,7 +3055,7 @@
                     item.resolve(result);
                 }
 
-                requestAnimationFrame(showNext);
+                scheduleShowNext();
             };
 
             const dismissDialog = () => {
@@ -3128,6 +3129,19 @@
                 alertRoot.setAttribute('aria-hidden', 'false');
                 isOpen = true;
                 requestAnimationFrame(focusFirstElement);
+            };
+
+            const scheduleShowNext = () => {
+                if (isOpen || showScheduled || queue.length === 0) {
+                    return;
+                }
+                showScheduled = true;
+                requestAnimationFrame(() => {
+                    showScheduled = false;
+                    if (!isOpen) {
+                        showNext();
+                    }
+                });
             };
 
             if (overlay) {
@@ -3241,7 +3255,7 @@
                 return new Promise(resolve => {
                     item.resolve = resolve;
                     queue.push(item);
-                    showNext();
+                    scheduleShowNext();
                 });
             };
 


### PR DESCRIPTION
## Summary
- add scheduling guard for the custom alert queue so dialogs open on the next animation frame
- avoid reopening dialogs while one is active by tracking scheduled work

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4b8beb12c83269b961ed569926329