### PR TITLE
Ensure timetable expands for all teacher columns

### DIFF
--- a/index.html
+++ b/index.html
@@ -1120,7 +1120,7 @@
         }
 
         .timetable {
-            min-width: 900px;
+            min-width: var(--timetable-min-width, 900px);
             width: 100%;
             border-collapse: separate;
             border-spacing: 0;
@@ -7970,6 +7970,17 @@
             headerRow.appendChild(lineHeader);
 
             const teacherList = Array.isArray(teachers) ? teachers : [];
+
+            const timetableElement = document.getElementById('timetable');
+            if (timetableElement) {
+                const BASE_LINE_COLUMN_WIDTH = 150;
+                const TEACHER_COLUMN_MIN_WIDTH = 220;
+                const calculatedMinWidth = Math.max(
+                    900,
+                    BASE_LINE_COLUMN_WIDTH + teacherList.length * TEACHER_COLUMN_MIN_WIDTH
+                );
+                timetableElement.style.setProperty('--timetable-min-width', `${calculatedMinWidth}px`);
+            }
 
             teacherList.forEach((teacherName, index) => {
                 const columnHeader = document.createElement('th');


### PR DESCRIPTION
## Summary
- allow the timetable to expose a CSS variable driven minimum width so the grid can grow with additional teachers
- compute the minimum width in JavaScript using the current teacher count so the last column is never clipped

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d4d110d8f48326bf2fa038d9e691b7